### PR TITLE
Allows for non-secure (http) hosts

### DIFF
--- a/src/Fs.php
+++ b/src/Fs.php
@@ -170,9 +170,10 @@ class Fs extends FlysystemFs
     {
         $endpoint = App::parseEnv($this->endpoint);
 
-        if (!str_contains($endpoint, 'https')) {
-            $endpoint = 'https://' .  $endpoint;
-        }
+        // defaults to https if no protocol is set
+        // allows for explicit http (not recommended outside local development)
+        $endpoint = str_starts_with( $endpoint, '//'   ) ? 'https:'   . $endpoint : $endpoint;
+        $endpoint = str_starts_with( $endpoint, 'http' ) ? $endpoint : 'https://' . $endpoint;
 
         return [
             'version'      => 'latest',

--- a/src/Fs.php
+++ b/src/Fs.php
@@ -168,12 +168,12 @@ class Fs extends FlysystemFs
      */
     protected function getConfigArray(): array
     {
-        $endpoint = App::parseEnv($this->endpoint);
+        $endpoint = ltrim( App::parseEnv($this->endpoint), '/');
 
         // defaults to https if no protocol is set
-        // allows for explicit http (not recommended outside local development)
-        $endpoint = str_starts_with( $endpoint, '//'   ) ? 'https:'   . $endpoint : $endpoint;
-        $endpoint = str_starts_with( $endpoint, 'http' ) ? $endpoint : 'https://' . $endpoint;
+        if (!str_starts_with($endpoint, 'http')) {
+            $endpoint = 'https://' .  $endpoint;
+        }
 
         return [
             'version'      => 'latest',


### PR DESCRIPTION
Improves endpoint auto-detect/sanitize so 'https://' isn't forced if 'http://' is already set. Still defaults to a secure connection if not specified.

Useful for local development without SSL.

