### PR TITLE
Add workaround for non-AWS file systems

### DIFF
--- a/src/Fs.php
+++ b/src/Fs.php
@@ -178,6 +178,8 @@ class Fs extends FlysystemFs
             'version'      => 'latest',
             'region'       => App::parseEnv($this->region),
             'endpoint'     => $endpoint,
+            'request_checksum_calculation' => 'when_required',
+            'response_checksum_validation' => 'when_required',
             'use_path_style_endpoint' => App::parseEnv($this->endpointType) === 'path',
             'http_handler' => new GuzzleHandler(Craft::createGuzzleClient()),
             'credentials'  => [


### PR DESCRIPTION
An added workaround for [recent changes to the AWS SDK](https://github.com/aws/aws-sdk-php/issues/3062) that have prevented S3-compatible third-party systems from working. Borrowing [from a listed fix](https://github.com/thephpleague/flysystem/issues/1845) in the flysystem repository.

Have tested locally, it works without issues.